### PR TITLE
Targeting OpenGL 3.2 (Platform)

### DIFF
--- a/platform/CMakeLists.txt
+++ b/platform/CMakeLists.txt
@@ -115,7 +115,7 @@ if(UNIX)
     target_link_libraries(platform dl)
 elseif(WIN32)
     target_compile_options(platform PRIVATE -static -static-libstdc++ -static-libgcc)
-    target_link_libraries(platform Secur32)
+    target_link_libraries(platform Secur32 ws2_32)
     target_include_directories(platform PRIVATE
             ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/glew-2.2.0/include/)
 endif()

--- a/platform/graphics/graphics_camera.c
+++ b/platform/graphics/graphics_camera.c
@@ -61,8 +61,6 @@ PLCamera *plCreateCamera(void) {
      */
     camera->viewport.w      = CAMERA_DEFAULT_WIDTH;
     camera->viewport.h      = CAMERA_DEFAULT_HEIGHT;
-    camera->viewport.r_w    = 0;
-    camera->viewport.r_h    = 0;
 
     camera->forward = PLVector3(0, 0, 1);
     camera->up = PLVector3(0, 1, 0);
@@ -84,7 +82,6 @@ void plDeleteCamera(PLCamera *camera) {
 
     CallGfxFunction(DeleteCamera, camera);
 
-    free(camera->viewport.v_buffer);
     free(camera);
 }
 
@@ -102,10 +99,6 @@ void plSetupCamera(PLCamera *camera) {
     plAssert(camera);
 
     CallGfxFunction(SetupCamera, camera);
-}
-
-void plDrawPerspectivePOST(PLCamera *camera) {
-    CallGfxFunction(DrawPerspectivePOST, camera);
 }
 
 const PLViewport *plGetCurrentViewport(void) {

--- a/platform/graphics/graphics_private.h
+++ b/platform/graphics/graphics_private.h
@@ -113,6 +113,12 @@ typedef struct GfxLayer {
     void(*DrawMesh)(PLMesh *mesh);
     void(*DeleteMesh)(PLMesh *mesh);
 
+    // Framebuffer
+    void(*CreateFrameBuffer)(PLFrameBuffer *buffer);
+    void(*DeleteFrameBuffer)(PLFrameBuffer *buffer);
+    void(*BindFrameBuffer)(PLFrameBuffer *buffer, PLFBOTarget targetBinding);
+    void(*BlitFrameBuffers)(PLFrameBuffer *srcBuffer, unsigned int srcW, unsigned int srcH, PLFrameBuffer *dstBuffer, unsigned int dstW, unsigned int dstH, bool linear );
+
     // Texture
     void(*CreateTexture)(PLTexture *texture);
     void(*DeleteTexture)(PLTexture *texture);
@@ -127,7 +133,6 @@ typedef struct GfxLayer {
     void(*DeleteCamera)(PLCamera *camera);
     void(*SetupCamera)(PLCamera *camera);
     ///////////////////////////////////////////
-    void(*DrawPerspectivePOST)(PLCamera *camera);
 
     // Shaders
     void(*CreateShaderProgram)(PLShaderProgram *program);

--- a/platform/graphics/graphics_shader.c
+++ b/platform/graphics/graphics_shader.c
@@ -69,8 +69,8 @@ void plPreProcessGLSLShader(char **buf, size_t *length) {
     InsertString(n_pos, "#version 150\n"); //OpenGL 3.2 == GLSL 150
 
     /* built-in uniforms */
-    InsertString(n_pos, "uniform mat4 modelView;");
-    InsertString(n_pos, "uniform mat4 proj;");
+    InsertString(n_pos, "uniform mat4 pl_model_view;");
+    InsertString(n_pos, "uniform mat4 pl_proj;");
 
     while(*pos != '\0') {
         if(*pos == '\n' || *pos == '\r' || *pos == '\t') {

--- a/platform/graphics/graphics_shader.c
+++ b/platform/graphics/graphics_shader.c
@@ -66,11 +66,11 @@ void plPreProcessGLSLShader(char **buf, size_t *length) {
 #define SkipSpaces()            while(*pos == ' ') { pos++; }
 #define SkipLine()              while(*pos != '\n' && *pos != '\r') { pos++; }
 
-    InsertString(n_pos, "#version 120\n");
+    InsertString(n_pos, "#version 150\n"); //OpenGL 3.2 == GLSL 150
 
     /* built-in uniforms */
-    InsertString(n_pos, "uniform mat4 pl_model_matrix;");
-    InsertString(n_pos, "uniform mat4 pl_projection_matrix;");
+    InsertString(n_pos, "uniform mat4 modelView;");
+    InsertString(n_pos, "uniform mat4 proj;");
 
     while(*pos != '\0') {
         if(*pos == '\n' || *pos == '\r' || *pos == '\t') {

--- a/platform/graphics/platform_graphics.c
+++ b/platform/graphics/platform_graphics.c
@@ -142,15 +142,15 @@ void plDeleteFrameBuffer(PLFrameBuffer *buffer) {
     //TODO: Dealloc object here
 }
 
-void plBindFrameBuffer(PLFrameBuffer *buffer, PLFBOTarget targetBinding) {
+void plBindFrameBuffer(PLFrameBuffer *buffer, PLFBOTarget target_binding) {
     //NOTE: NULL is valid for *buffer, to bind the SDL window default backbuffer
-    CallGfxFunction(BindFrameBuffer, buffer, targetBinding)
+    CallGfxFunction(BindFrameBuffer, buffer, target_binding)
 }
 
-void plBlitFrameBuffers(PLFrameBuffer *srcBuffer, unsigned int srcW, unsigned int srcH, PLFrameBuffer *dstBuffer, unsigned int dstW, unsigned int dstH, bool linear ) {
+void plBlitFrameBuffers(PLFrameBuffer *src_buffer, unsigned int src_w, unsigned int src_h, PLFrameBuffer *dst_buffer, unsigned int dst_w, unsigned int dst_h, bool linear ) {
     //NOTE: NULL is valid for *srcBuffer/*dstBuffer, to bind the SDL window default backbuffer
     //      SRC and DST can be the same buffer, in order to quickly copy a subregion of the buffer to a new location
-    CallGfxFunction(BlitFrameBuffers, srcBuffer, srcW, srcH, dstBuffer, dstW, dstH, linear);
+    CallGfxFunction(BlitFrameBuffers, src_buffer, src_w, src_h, dst_buffer, dst_w, dst_h, linear);
 }
 
 void plSetClearColour(PLColour rgba) {

--- a/platform/graphics/platform_graphics.c
+++ b/platform/graphics/platform_graphics.c
@@ -113,20 +113,21 @@ bool plHWSupportsShaders(void) {
 	FRAMEBUFFERS
 ===========================*/
 
-PLFrameBuffer *plCreateFrameBuffer(unsigned int w, unsigned int h) {
+PLFrameBuffer *plCreateFrameBuffer(unsigned int w, unsigned int h, PLFBORenderFlags flags) {
+    if(flags == 0){
+        return NULL;
+    }
+
     PLFrameBuffer *buffer = (PLFrameBuffer*)pl_malloc(sizeof(PLFrameBuffer));
     if(!buffer) {
         return NULL;
     }
 
-#if 0
-    glGenFramebuffers(1, &buffer->fbo);
-    glGenRenderbuffers(1, &buffer->rbo);
-    glBindRenderbuffer(GL_RENDERBUFFER, buffer->rbo);
-    glRenderbufferStorage(GL_RENDERBUFFER, GL_RGBA8, w, h);
-    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, buffer->fbo);
-    glFramebufferRenderbuffer(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, buffer->rbo);
-#endif
+    buffer->width = w;
+    buffer->height = h;
+    buffer->flags = flags;
+
+    CallGfxFunction(CreateFrameBuffer, buffer);
 
     return buffer;
 }
@@ -136,21 +137,20 @@ void plDeleteFrameBuffer(PLFrameBuffer *buffer) {
         return;
     }
 
-#if 0
-    glDeleteFramebuffers(1, &buffer->fbo);
-    glDeleteRenderbuffers(1, &buffer->rbo);
-#endif
+    CallGfxFunction(DeleteFrameBuffer, buffer);
+
+    //TODO: Dealloc object here
 }
 
-void plBindFrameBuffer(PLFrameBuffer *buffer) {
-    if(buffer == NULL) {
-        // todo, warning regarding invalid buffer blah blah
-        return;
-    }
+void plBindFrameBuffer(PLFrameBuffer *buffer, PLFBOTarget targetBinding) {
+    //NOTE: NULL is valid for *buffer, to bind the SDL window default backbuffer
+    CallGfxFunction(BindFrameBuffer, buffer, targetBinding)
+}
 
-#if defined(PL_MODE_OPENGL)
-    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, buffer->fbo);
-#endif
+void plBlitFrameBuffers(PLFrameBuffer *srcBuffer, unsigned int srcW, unsigned int srcH, PLFrameBuffer *dstBuffer, unsigned int dstW, unsigned int dstH, bool linear ) {
+    //NOTE: NULL is valid for *srcBuffer/*dstBuffer, to bind the SDL window default backbuffer
+    //      SRC and DST can be the same buffer, in order to quickly copy a subregion of the buffer to a new location
+    CallGfxFunction(BlitFrameBuffers, srcBuffer, srcW, srcH, dstBuffer, dstW, dstH, linear);
 }
 
 void plSetClearColour(PLColour rgba) {

--- a/platform/graphics/platform_graphics_font.c
+++ b/platform/graphics/platform_graphics_font.c
@@ -297,7 +297,7 @@ void plDrawBitmapCharacter(PLBitmapFont *font, int x, int y, float scale, PLColo
     if(mesh == NULL) {
         if((mesh = plCreateMesh(
                 PL_MESH_TRIANGLE_STRIP,
-                PL_DRAW_IMMEDIATE,
+                PL_DRAW_DYNAMIC,
                 2, 4
         )) == NULL) {
             return;

--- a/platform/include/PL/platform_graphics.h
+++ b/platform/include/PL/platform_graphics.h
@@ -147,7 +147,8 @@ typedef enum PLFBORenderFlags {
 
 typedef struct PLFrameBuffer {
     unsigned int fbo;
-    unsigned int rbo[3];//Colour / depth / stencil
+    unsigned int rbo_colour;
+    unsigned int rbo_depth;
     unsigned int width;
     unsigned int height;
     PLFBORenderFlags flags;
@@ -155,8 +156,12 @@ typedef struct PLFrameBuffer {
 
 PL_EXTERN_C
 
-PL_EXTERN void plSetClearColour(PLColour rgba);
+PL_EXTERN PLFrameBuffer *plCreateFrameBuffer(unsigned int w, unsigned int h, PLFBORenderFlags flags);
+PL_EXTERN void plDeleteFrameBuffer(PLFrameBuffer *buffer);
+PL_EXTERN void plBindFrameBuffer(PLFrameBuffer *buffer, PLFBOTarget target_binding);
+PL_EXTERN void plBlitFrameBuffers(PLFrameBuffer *src_buffer, unsigned int src_w, unsigned int src_h, PLFrameBuffer *dst_buffer, unsigned int dst_w, unsigned int dst_h, bool linear );
 
+PL_EXTERN void plSetClearColour(PLColour rgba);
 PL_EXTERN void plClearBuffers(unsigned int buffers);
 
 PL_EXTERN_C_END

--- a/platform/include/PL/platform_graphics.h
+++ b/platform/include/PL/platform_graphics.h
@@ -52,12 +52,6 @@ typedef unsigned int PLRenderBuffer;
 
 typedef void PLGraphicsContext;
 
-typedef struct PLFrameBuffer {
-#if defined(PL_MODE_OPENGL)
-    unsigned int fbo, rbo;
-#endif
-} PLFrameBuffer;
-
 typedef enum PLDataFormat {
     PL_UNSIGNED_BYTE,
     PL_UNSIGNED_INT_8_8_8_8_REV,
@@ -145,11 +139,19 @@ typedef enum PLFBOTarget {
     PL_FRAMEBUFFER_READ
 } PLFBOTarget;
 
-enum {
+typedef enum PLFBORenderFlags {
     PL_BUFFER_COLOUR    = (1 << 0),
     PL_BUFFER_DEPTH     = (1 << 1),
     PL_BUFFER_STENCIL   = (1 << 2),
-};
+} PLFBORenderFlags;
+
+typedef struct PLFrameBuffer {
+    unsigned int fbo;
+    unsigned int rbo[3];//Colour / depth / stencil
+    unsigned int width;
+    unsigned int height;
+    PLFBORenderFlags flags;
+} PLFrameBuffer;
 
 PL_EXTERN_C
 

--- a/platform/include/PL/platform_graphics_camera.h
+++ b/platform/include/PL/platform_graphics_camera.h
@@ -36,17 +36,10 @@ enum {
 };
 
 typedef struct PLViewport {
+    bool autoScale; //If true, viewport will update to match height/width of currently bound FBO when SetupCamera() is called
     int x, y;
     int h;
     int w;
-
-    uint8_t *v_buffer;
-    unsigned int buffers[32];
-
-    PLImageFormat format;
-
-    int r_w, r_h;
-    int old_r_w, old_r_h;
 } PLViewport;
 
 typedef struct PLCamera {
@@ -72,8 +65,6 @@ PL_EXTERN PLCamera *plCreateCamera(void);
 PL_EXTERN void plDeleteCamera(PLCamera *camera);
 
 PL_EXTERN void plSetupCamera(PLCamera *camera);
-
-PL_EXTERN void plDrawPerspectivePOST(PLCamera *camera);
 
 PL_EXTERN const PLViewport *plGetCurrentViewport(void);
 

--- a/platform/include/PL/platform_graphics_camera.h
+++ b/platform/include/PL/platform_graphics_camera.h
@@ -36,7 +36,7 @@ enum {
 };
 
 typedef struct PLViewport {
-    bool autoScale; //If true, viewport will update to match height/width of currently bound FBO when SetupCamera() is called
+    bool auto_scale; //If true, viewport will update to match height/width of currently bound FBO when SetupCamera() is called
     int x, y;
     int h;
     int w;

--- a/platform/include/PL/platform_mesh.h
+++ b/platform/include/PL/platform_mesh.h
@@ -46,16 +46,16 @@ typedef enum PLMeshPrimitive {
 } PLMeshPrimitive;
 
 typedef enum PLMeshDrawMode {
-    PL_DRAW_DYNAMIC,
+    PL_DRAW_STREAM,
     PL_DRAW_STATIC,
-    PL_DRAW_IMMEDIATE,  // Not necessarily supported in all cases, will just revert to dynamic otherwise!
+    PL_DRAW_DYNAMIC,
 
     PL_NUM_DRAWMODES
 } PLMeshDrawMode;
 
 typedef struct PLVertex {
     PLVector3 position, normal;
-    PLVector2 st[16];
+    PLVector2 st[1];//[16]; Limit to one UV channel while setting up graphics
 
     PLColour colour;
 } PLVertex;

--- a/platform/model/model_cyclone.c
+++ b/platform/model/model_cyclone.c
@@ -296,7 +296,7 @@ PLModel *LoadStaticRequiemModel(FILE *fp) {
     ModelLog("num_indices:         %d\n", num_indices);
 #endif
 
-    PLMesh *mesh = plCreateMesh(PL_MESH_TRIANGLES, PL_DRAW_IMMEDIATE, num_triangles, num_vertices);
+    PLMesh *mesh = plCreateMesh(PL_MESH_TRIANGLES, PL_DRAW_DYNAMIC, num_triangles, num_vertices);
     if(mesh == NULL) {
         return NULL;
     }

--- a/platform/model/model_hdv.c
+++ b/platform/model/model_hdv.c
@@ -125,7 +125,7 @@ PLModel *plLoadHDVModel(const char *path) {
     fclose(file);
     file = NULL;
 
-    PLMesh *mesh = plCreateMesh(PL_MESH_TRIANGLES, PL_DRAW_IMMEDIATE,
+    PLMesh *mesh = plCreateMesh(PL_MESH_TRIANGLES, PL_DRAW_DYNAMIC,
                                 (unsigned int) (header.num_faces - 2) * 2, header.num_vertices);
     if(mesh == NULL) {
         goto ABORT;

--- a/platform/model/model_mesh.c
+++ b/platform/model/model_mesh.c
@@ -282,7 +282,7 @@ void plDrawRaisedBox(int x, int y, unsigned int w, unsigned int h) {
     if(mesh == NULL) {
         if((mesh = plCreateMesh(
                 PL_MESH_LINES,
-                PL_DRAW_IMMEDIATE,
+                PL_DRAW_DYNAMIC,
                 0, 4
         )) == NULL) {
             return;
@@ -295,7 +295,7 @@ void plDrawBevelledBorder(int x, int y, unsigned int w, unsigned int h) {
     if(mesh == NULL) {
         if((mesh = plCreateMesh(
                 PL_MESH_LINES,
-                PL_DRAW_IMMEDIATE,
+                PL_DRAW_DYNAMIC,
                 0, 16
         )) == NULL) {
             return;
@@ -372,7 +372,7 @@ void plDrawEllipse(unsigned int segments, PLVector2 position, float w, float h, 
     if(mesh == NULL) {
         if((mesh = plCreateMesh(
                 PL_MESH_TRIANGLE_FAN,
-                PL_DRAW_IMMEDIATE,
+                PL_DRAW_DYNAMIC,
                 0, segments
         )) == NULL) {
             return;
@@ -400,7 +400,7 @@ void plDrawTexturedRectangle(int x, int y, int w, int h, PLTexture *texture) {
     if(mesh == NULL) {
         if((mesh = plCreateMesh(
                 PL_MESH_TRIANGLE_STRIP,
-                PL_DRAW_IMMEDIATE,
+                PL_DRAW_DYNAMIC,
                 2, 4
         )) == NULL) {
             return;
@@ -435,7 +435,7 @@ void plDrawRectangle(int x, int y, unsigned int w, unsigned int h, PLColour colo
     if(mesh == NULL) {
         if((mesh = plCreateMesh(
                 PL_MESH_LINE_LOOP,
-                PL_DRAW_IMMEDIATE,
+                PL_DRAW_DYNAMIC,
                 0, 4
         )) == NULL) {
             return;
@@ -460,7 +460,7 @@ void plDrawFilledRectangle(PLRectangle2D rect) {
     if(mesh == NULL) {
         if((mesh = plCreateMesh(
                 PL_MESH_TRIANGLE_STRIP,
-                PL_DRAW_IMMEDIATE,
+                PL_DRAW_DYNAMIC,
                 2, 4
         )) == NULL) {
             return;
@@ -489,7 +489,7 @@ void plDrawTriangle(int x, int y, unsigned int w, unsigned int h) {
     if (mesh == NULL) {
         if((mesh = plCreateMesh(
                 PL_MESH_TRIANGLE_FAN,
-                PL_DRAW_IMMEDIATE,
+                PL_DRAW_DYNAMIC,
                 1, 3
         )) == NULL) {
             return;

--- a/platform/package/package_sfa.c
+++ b/platform/package/package_sfa.c
@@ -27,6 +27,8 @@ For more information, please refer to <http://unlicense.org>
 
 #include "package_private.h"
 
+#include "3rdparty/portable_endian.h"
+
 /* Loader for SFA TAB/BIN format */
 
 static bool LoadTABPackageFile(FILE *fh, PLPackageIndex *pi) {

--- a/platform/platform_console.c
+++ b/platform/platform_console.c
@@ -335,7 +335,7 @@ PLresult plInitConsole(void) {
 
 #if 0 /* todo, move this into graphics init code */
 #if defined(PL_USE_GRAPHICS)
-    if((mesh_line = plCreateMesh(PL_MESH_LINES, PL_DRAW_IMMEDIATE, 0, 4)) == NULL) {
+    if((mesh_line = plCreateMesh(PL_MESH_LINES, PL_DRAW_DYNAMIC, 0, 4)) == NULL) {
         return PL_RESULT_MEMORY_ALLOCATION;
     }
 #endif


### PR DESCRIPTION
- Updated OpenGL context to 3.2 core / GLSL #150
- Removed deprecated OpenGL 2.2 fixed function pipeline calls, all meshes now render as dynamic_draw VBO buffers
- Detached render target management from camera class
- Made "Ingame" and "Frontend" scenes to render to seperate internal 640x480 targets, laying the groundwork for configurable internal resolution
- Added new platform functions to create, destroy, bind, and blit  platform framebuffer objects
